### PR TITLE
Fix __HAL_TSC_GET_GROUP_STATUS to report requested group index

### DIFF
--- a/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_tsc.h
+++ b/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_tsc.h
@@ -572,7 +572,7 @@ typedef  void (*pTSC_CallbackTypeDef)(TSC_HandleTypeDef *htsc); /*!< pointer to 
   * @retval SET or RESET
   */
 #define __HAL_TSC_GET_GROUP_STATUS(__HANDLE__, __GX_INDEX__) \
-((((__HANDLE__)->Instance->IOGCSR & (uint32_t)(1UL << (((__GX_INDEX__) & (uint32_t)TSC_NB_OF_GROUPS) + 16UL))) == (uint32_t)(1UL << (((__GX_INDEX__) & (uint32_t)TSC_NB_OF_GROUPS) + 16UL))) ? TSC_GROUP_COMPLETED : TSC_GROUP_ONGOING)
+((((__HANDLE__)->Instance->IOGCSR & (uint32_t)(1UL << ((__GX_INDEX__) + 16UL))) == (uint32_t)(1UL << ((__GX_INDEX__) + 16UL))) ? TSC_GROUP_COMPLETED : TSC_GROUP_ONGOING)
 
 /**
   * @}


### PR DESCRIPTION
The current implementation of __HAL_TSC_GET_GROUP_STATUS incorrectly
applies a mask to the requested TSC group index which results in the
status of TSC group index 0 being returned rather than the requested TSC
group index.

Modify so that the __GX_INDEX__ input to __HAL_TSC_GET_GROUP_STATUS is
honoured and the correct group index status is returned.

This bug has previously been reported at
https://community.st.com/s/question/0D50X0000ASrqJjSQJ/bug-in-stm32l0-tsc-library

Fixes #7 