### PR TITLE
Allow VECT_TAB_OFFSET to be overridden externally

### DIFF
--- a/Drivers/CMSIS/Device/ST/STM32L0xx/Source/Templates/system_stm32l0xx.c
+++ b/Drivers/CMSIS/Device/ST/STM32L0xx/Source/Templates/system_stm32l0xx.c
@@ -80,8 +80,10 @@
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
 /* #define VECT_TAB_SRAM */
+#ifndef VECT_TAB_OFFSET
 #define VECT_TAB_OFFSET  0x00U /*!< Vector Table base offset field.
                                    This value must be a multiple of 0x100. */
+#endif
 /******************************************************************************/
 /**
   * @}


### PR DESCRIPTION
This patch allows the VECT_TAB_OFFSET #define to be overridden by the IDE or Makefile without manually editing the system_stm32l0xx.c file. It is useful if the application must be compiled for debugging (no vector table offset) or for release (vector table offset to accommodate a bootloader).

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeL0/blob/master/CONTRIBUTING.md) file.
