### PR TITLE
Allow VECT_TAB_OFFSET to be overridden externally (IDE or Makefile)

### DIFF
--- a/Drivers/CMSIS/Device/ST/STM32L0xx/Source/Templates/system_stm32l0xx.c
+++ b/Drivers/CMSIS/Device/ST/STM32L0xx/Source/Templates/system_stm32l0xx.c
@@ -80,8 +80,10 @@
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
 /* #define VECT_TAB_SRAM */
+#ifndef VECT_TAB_OFFSET
 #define VECT_TAB_OFFSET  0x00U /*!< Vector Table base offset field.
                                    This value must be a multiple of 0x100. */
+#endif
 /******************************************************************************/
 /**
   * @}


### PR DESCRIPTION
It is useful to allow VECT_TAB_OFFSET to be overridden externally in the IDE or Makefile. This allows the Vector Table Offset to be at 0 for a debug build and the Vector Table Offset to be moved for a release build that has to accommodate a bootloader.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeL0/blob/master/CONTRIBUTING.md) file.
