### PR TITLE
fix adafruit 1.8 tft shield sd card driver

### DIFF
--- a/Drivers/BSP/Adafruit_Shield/stm32_adafruit_sd.h
+++ b/Drivers/BSP/Adafruit_Shield/stm32_adafruit_sd.h
@@ -207,8 +207,8 @@ typedef struct
   * @{
   */   
 uint8_t BSP_SD_Init(void);
-uint8_t BSP_SD_ReadBlocks(uint32_t *pData, uint32_t ReadAddr, uint32_t NumOfBlocks, uint32_t Timeout);
-uint8_t BSP_SD_WriteBlocks(uint32_t *pData, uint32_t WriteAddr, uint32_t NumOfBlocks, uint32_t Timeout);
+uint8_t BSP_SD_ReadBlocks(uint32_t *pData, uint32_t ReadAddr, uint16_t BlockSize, uint32_t NumberOfBlocks);
+uint8_t BSP_SD_WriteBlocks(uint32_t *pData, uint32_t WriteAddr, uint16_t BlockSize, uint32_t NumberOfBlocks);
 uint8_t BSP_SD_Erase(uint32_t StartAddr, uint32_t EndAddr);
 uint8_t BSP_SD_GetCardState(void);
 uint8_t BSP_SD_GetCardInfo(SD_CardInfo *pCardInfo);

--- a/Projects/NUCLEO-L053R8/Applications/FatFs/FatFs_uSD_RTOS/Src/sd_diskio.c
+++ b/Projects/NUCLEO-L053R8/Applications/FatFs/FatFs_uSD_RTOS/Src/sd_diskio.c
@@ -127,7 +127,7 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
 {
   DRESULT res = RES_ERROR;
   if(BSP_SD_ReadBlocks((uint32_t*)buff,
-                       (uint64_t)(sector * SD_BLOCK_SIZE),
+                       (uint32_t)(sector),
                        SD_BLOCK_SIZE, count) == MSD_OK)
   {
     /* wait until the read operation is finished */
@@ -154,7 +154,7 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
   DRESULT res = RES_ERROR;
 
   if(BSP_SD_WriteBlocks((uint32_t*)buff,
-                        (uint64_t)(sector * SD_BLOCK_SIZE),
+                        (uint32_t)(sector),
                         SD_BLOCK_SIZE, count) == MSD_OK)
 
   {

--- a/Projects/NUCLEO-L053R8/Applications/FatFs/FatFs_uSD_Standalone/Src/sd_diskio.c
+++ b/Projects/NUCLEO-L053R8/Applications/FatFs/FatFs_uSD_Standalone/Src/sd_diskio.c
@@ -127,7 +127,7 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
 {
   DRESULT res = RES_ERROR;
   if(BSP_SD_ReadBlocks((uint32_t*)buff,
-                       (uint64_t)(sector * SD_BLOCK_SIZE),
+                       (uint32_t)(sector),
                        SD_BLOCK_SIZE, count) == MSD_OK)
   {
     /* wait until the read operation is finished */
@@ -154,7 +154,7 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
   DRESULT res = RES_ERROR;
 
   if(BSP_SD_WriteBlocks((uint32_t*)buff,
-                        (uint64_t)(sector * SD_BLOCK_SIZE),
+                        (uint32_t)(sector),
                         SD_BLOCK_SIZE, count) == MSD_OK)
 
   {

--- a/Projects/NUCLEO-L053R8/Demonstrations/Src/sd_diskio.c
+++ b/Projects/NUCLEO-L053R8/Demonstrations/Src/sd_diskio.c
@@ -127,7 +127,7 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
 {
   DRESULT res = RES_ERROR;
   if(BSP_SD_ReadBlocks((uint32_t*)buff,
-                       (uint64_t)(sector * SD_BLOCK_SIZE),
+                       (uint32_t)(sector),
                        SD_BLOCK_SIZE, count) == MSD_OK)
   {
     /* wait until the read operation is finished */
@@ -154,7 +154,7 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
   DRESULT res = RES_ERROR;
 
   if(BSP_SD_WriteBlocks((uint32_t*)buff,
-                        (uint64_t)(sector * SD_BLOCK_SIZE),
+                        (uint32_t)(sector),
                         SD_BLOCK_SIZE, count) == MSD_OK)
 
   {

--- a/Projects/NUCLEO-L073RZ/Demonstrations/Adafruit_LCD_1_8_SD_Joystick/Src/sd_diskio.c
+++ b/Projects/NUCLEO-L073RZ/Demonstrations/Adafruit_LCD_1_8_SD_Joystick/Src/sd_diskio.c
@@ -127,7 +127,7 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
 {
   DRESULT res = RES_ERROR;
   if(BSP_SD_ReadBlocks((uint32_t*)buff,
-                       (uint64_t)(sector * SD_BLOCK_SIZE),
+                       (uint32_t)(sector),
                        SD_BLOCK_SIZE, count) == MSD_OK)
   {
     /* wait until the read operation is finished */
@@ -154,7 +154,7 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
   DRESULT res = RES_ERROR;
 
   if(BSP_SD_WriteBlocks((uint32_t*)buff,
-                        (uint64_t)(sector * SD_BLOCK_SIZE),
+                        (uint32_t)(sector),
                         SD_BLOCK_SIZE, count) == MSD_OK)
 
   {


### PR DESCRIPTION
Fixes the Adafruit 1.8" TFT Shield's (V1 or V2) SD card driver used in all STM32CubeL0 demos.

The `BSP_SD_ReadBlocks` and `BSP_SD_WriteBlocks` API had fallen out of sync in the current demonstration projects rendering the SD card inaccessible for the display images.

This has been fixed, along with a necessary change to how they are called from `sd_diskio.c`.  Sector numbers are passed into the BSP drivers, allowing for use with cards having capacity less than 2 GB as well as greater than 4 GB.

This fix is required to support the **Adafruit 1.8" TFT Shield V2** featuring the seesaw I2C expander that I have implemented in my branch https://github.com/firmwaremodules/STM32CubeL0/tree/adafruit-lcd-seesaw and documented in https://github.com/firmwaremodules/STM32CubeL0/issues/1.





