### PR TITLE
Speed up the USB IRQ handler

### DIFF
--- a/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pcd.c
+++ b/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pcd.c
@@ -1003,14 +1003,16 @@ HAL_StatusTypeDef HAL_PCD_Stop(PCD_HandleTypeDef *hpcd)
   */
 void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
 {
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_CTR))
+  uint16_t wIstr = hpcd->Instance->ISTR;
+ 
+  if (wIstr & USB_ISTR_CTR)
   {
     /* servicing of the endpoint correct transfer interrupt */
     /* clear of the CTR flag into the sub */
     (void)PCD_EP_ISR_Handler(hpcd);
   }
 
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_RESET))
+  if (wIstr & USB_ISTR_RESET)
   {
     __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_RESET);
 
@@ -1023,17 +1025,17 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
     (void)HAL_PCD_SetAddress(hpcd, 0U);
   }
 
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_PMAOVR))
+  if (wIstr & USB_ISTR_PMAOVR)
   {
     __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_PMAOVR);
   }
 
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_ERR))
+  if (wIstr & USB_ISTR_ERR)
   {
     __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_ERR);
   }
 
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_WKUP))
+  if (wIstr & USB_ISTR_WKUP)
   {
     hpcd->Instance->CNTR &= (uint16_t) ~(USB_CNTR_LPMODE);
     hpcd->Instance->CNTR &= (uint16_t) ~(USB_CNTR_FSUSP);
@@ -1057,7 +1059,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
     __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_WKUP);
   }
 
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_SUSP))
+  if (wIstr & USB_ISTR_SUSP)
   {
     /* Force low-power mode in the macrocell */
     hpcd->Instance->CNTR |= (uint16_t)USB_CNTR_FSUSP;
@@ -1075,7 +1077,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
   }
 
   /* Handle LPM Interrupt */
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_L1REQ))
+  if (wIstr & USB_ISTR_L1REQ)
   {
     __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_L1REQ);
     if (hpcd->LPM_State == LPM_L0)
@@ -1102,7 +1104,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
     }
   }
 
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_SOF))
+  if (wIstr & USB_ISTR_SOF)
   {
     __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_SOF);
 
@@ -1113,7 +1115,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
 #endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
   }
 
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_ESOF))
+  if (wIstr & USB_ISTR_ESOF)
   {
     /* clear ESOF flag in ISTR */
     __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_ESOF);


### PR DESCRIPTION
Avoid reading ISTR multiple times which is quite slow on L0 MCUs
Change follows the same pattern in PCD_EP_ISR_Handler. Cache the value in wIstr and do repeated checks on the variable.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeL0/blob/master/CONTRIBUTING.md) file.
