### PR TITLE
Make maximum number of USB endpoints configurable to reduce memory footprint

### DIFF
--- a/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_conf_template.h
+++ b/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_conf_template.h
@@ -190,6 +190,17 @@
 
 #define USE_SPI_CRC                   1U
 
+/* ################## USB peripheral configuration ########################## */
+
+/* To reduce memory footprint of entire USB stack we can reduce the
+ * amount of supported 'IN' and/or 'OUT' endpoints in the PCD HAL driver.
+ * If this HAL driver is used combination with the ST USB Device Library
+ * this will also modify the 'USBD_MAX_NUM_ENDPOINT_IN' and 'USBD_MAX_NUM_ENDPOINT_OUT'
+ * parameters accordingly
+ */
+// #define HAL_PCD_NUM_ENDPOINTS_IN      3U
+// #define HAL_PCD_NUM_ENDPOINTS_OUT     3U
+
 /* Includes ------------------------------------------------------------------*/
 /**
   * @brief Include module's header file 

--- a/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_pcd.h
+++ b/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_pcd.h
@@ -89,6 +89,19 @@ typedef USB_TypeDef        PCD_TypeDef;
 typedef USB_CfgTypeDef     PCD_InitTypeDef;
 typedef USB_EPTypeDef      PCD_EPTypeDef;
 
+/**
+ * Default value for HAL_PCD_NUM_ENDPOINTS_IN
+ */
+#ifndef HAL_PCD_NUM_ENDPOINTS_IN
+#define HAL_PCD_NUM_ENDPOINTS_IN 8U
+#endif /* HAL_PCD_NUM_ENDPOINTS_IN */
+
+/**
+ * Default value for HAL_PCD_NUM_ENDPOINTS_OUT
+ */
+#ifndef HAL_PCD_NUM_ENDPOINTS_OUT
+#define HAL_PCD_NUM_ENDPOINTS_OUT 8U
+#endif /* HAL_PCD_NUM_ENDPOINTS_OUT */
 
 /**
   * @brief  PCD Handle Structure definition
@@ -102,8 +115,8 @@ typedef struct
   PCD_TypeDef             *Instance;   /*!< Register base address             */
   PCD_InitTypeDef         Init;        /*!< PCD required parameters           */
   __IO uint8_t            USB_Address; /*!< USB Address                       */
-  PCD_EPTypeDef           IN_ep[8];   /*!< IN endpoint parameters             */
-  PCD_EPTypeDef           OUT_ep[8];  /*!< OUT endpoint parameters            */
+  PCD_EPTypeDef           IN_ep[HAL_PCD_NUM_ENDPOINTS_IN];    /*!< IN endpoint parameters             */
+  PCD_EPTypeDef           OUT_ep[HAL_PCD_NUM_ENDPOINTS_OUT];   /*!< OUT endpoint parameters            */
   HAL_LockTypeDef         Lock;        /*!< PCD peripheral status             */
   __IO PCD_StateTypeDef   State;       /*!< PCD communication state           */
   __IO  uint32_t          ErrorCode;   /*!< PCD Error code                    */

--- a/Middlewares/ST/STM32_USB_Device_Library/Core/Inc/usbd_def.h
+++ b/Middlewares/ST/STM32_USB_Device_Library/Core/Inc/usbd_def.h
@@ -65,6 +65,14 @@ extern "C" {
 #define USBD_SUPPORT_USER_STRING_DESC                   0U
 #endif /* USBD_SUPPORT_USER_STRING_DESC */
 
+#ifndef USBD_MAX_NUM_ENDPOINT_IN
+#define USBD_MAX_NUM_ENDPOINT_IN                        16U
+#endif /* USBD_MAX_NUM_ENDPOINT_IN */
+
+#ifndef USBD_MAX_NUM_ENDPOINT_OUT
+#define USBD_MAX_NUM_ENDPOINT_OUT                       16U
+#endif /* USBD_MAX_NUM_ENDPOINT_OUT */
+
 #define  USB_LEN_DEV_QUALIFIER_DESC                     0x0AU
 #define  USB_LEN_DEV_DESC                               0x12U
 #define  USB_LEN_CFG_DESC                               0x09U
@@ -145,7 +153,6 @@ extern "C" {
 #define USBD_EP_TYPE_ISOC                               0x01U
 #define USBD_EP_TYPE_BULK                               0x02U
 #define USBD_EP_TYPE_INTR                               0x03U
-
 
 /**
   * @}
@@ -241,8 +248,8 @@ typedef struct _USBD_HandleTypeDef
   uint32_t                dev_default_config;
   uint32_t                dev_config_status;
   USBD_SpeedTypeDef       dev_speed;
-  USBD_EndpointTypeDef    ep_in[16];
-  USBD_EndpointTypeDef    ep_out[16];
+  USBD_EndpointTypeDef    ep_in[USBD_MAX_NUM_ENDPOINT_IN];
+  USBD_EndpointTypeDef    ep_out[USBD_MAX_NUM_ENDPOINT_OUT];
   uint32_t                ep0_state;
   uint32_t                ep0_data_len;
   uint8_t                 dev_state;


### PR DESCRIPTION
```
The STM32L082 USB peripheral support up to 8 configurable USB endpoints.
However, depending on the application one might only need a few of them.
For example, for a CDC class application, only 3 endpoints are used in
addition to endpoint 0 (bidirectional endpoint):

 - CDC IN  endpoint  (USB IN): USB device (MCU) -> USB host (PC)
 - CDC OUT endpoint (USB OUT): USB host (PC) -> USB device (MCU)
 - CDC CMD endpoint  (USB IN): CDC commands

But, since USB device library is used on various chipsets, it provides
memory structure for up to 16 (!) bidirectional USB endpoints, which is
not even possible on the STM32L082. So all these extra memory structures
are wasted RAM.

This commit makes the allocation of these endpoint memory structure
configurable. Since the USB device library *depends on* the HAL, the HAL
is modified such that a user can define 'HAL_PCD_NUM_ENDPOINTS_IN' and
'HAL_PCD_NUM_ENDPOINTS_OUT' to one's needs in stm32l0xx_hal_conf.h. For
CDC class device one can define these as follows:

 #define HAL_PCD_NUM_ENDPOINTS_IN      3U
 #define HAL_PCD_NUM_ENDPOINTS_OUT     2U

If those settings need to be propagated through to the ST USB Device
libray, one must define the following object-like macro's in the
application's usbd_conf.h to link the HAL configuration with the USB
device library:

 #define USBD_MAX_NUM_ENDPOINT_IN       (HAL_PCD_NUM_ENDPOINTS_IN)
 #define USBD_MAX_NUM_ENDPOINT_OUT      (HAL_PCD_NUM_ENDPOINTS_OUT)
```

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeL0/blob/master/CONTRIBUTING.md) file.
